### PR TITLE
add support for "release" on old game worlds

### DIFF
--- a/main.js
+++ b/main.js
@@ -8,7 +8,7 @@ var Incheon = {
         Serializable: require("./src/composables/Serializable")
     },
     SyncStrategies:{
-        playerGradualSnap: require("./src/SyncStrategies/PlayerGradualSnap")
+        playerGradualSnap: require("./src/syncStrategies/PlayerGradualSnap")
     }
 
 };

--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@ var Incheon = {
     GameWorld: require("./src/GameWorld"),
     Point: require("./src/Point"),
     Composables: {
-        Serializable: require("./src/Composables/Serializable")
+        Serializable: require("./src/composables/Serializable")
     },
     SyncStrategies:{
         playerGradualSnap: require("./src/SyncStrategies/PlayerGradualSnap")

--- a/src/ClientEngine.js
+++ b/src/ClientEngine.js
@@ -65,11 +65,6 @@ class ClientEngine {
         // console.log(world.stepCount - this.gameEngine.world.stepCount);
         // console.log("last handled input", world.lastHandledInput);
 
-        // release worldBuffer resources
-        if (this.worldBuffer.length > 0) {
-            this.worldBuffer[this.worldBuffer.length - 1].release();
-        }
-
         this.worldBuffer.push(worldSnapshot);
         if (this.worldBuffer.length >= 5) { //pick a proper buffer length, make it configurable
             this.worldBuffer.shift();
@@ -79,9 +74,6 @@ class ClientEngine {
             if (worldSnapshot.objects.hasOwnProperty(objId)) {
                 this.options.syncStrategy.handleObject(worldSnapshot, objId);
             }
-        }
-        if (typeof this.gameEngine.worldUpdateHandler === 'function') {
-            this.gameEngine.worldUpdateHandler();
         }
 
         //finally update the stepCount

--- a/src/ClientEngine.js
+++ b/src/ClientEngine.js
@@ -80,8 +80,8 @@ class ClientEngine {
                 this.options.syncStrategy.handleObject(worldSnapshot, objId);
             }
         }
-        if (typeof this.gameEngine.worldUpdateHandler === 'function') {
-            this.gameEngine.worldUpdateHandler();
+        if (typeof this.worldUpdateHandler === 'function') {
+            this.worldUpdateHandler();
         }
 
         //finally update the stepCount

--- a/src/ClientEngine.js
+++ b/src/ClientEngine.js
@@ -80,8 +80,8 @@ class ClientEngine {
                 this.options.syncStrategy.handleObject(worldSnapshot, objId);
             }
         }
-        if (typeof this.worldUpdateHandler === 'function') {
-            this.worldUpdateHandler();
+        if (typeof this.gameEngine.worldUpdateHandler === 'function') {
+            this.gameEngine.worldUpdateHandler();
         }
 
         //finally update the stepCount

--- a/src/ClientEngine.js
+++ b/src/ClientEngine.js
@@ -1,6 +1,6 @@
 "use strict";
 var io = require("socket.io-client");
-var PlayerSnap = require("./SyncStrategies/PlayerSnap");
+var PlayerSnap = require("./syncStrategies/PlayerSnap");
 
 class ClientEngine {
 

--- a/src/ClientEngine.js
+++ b/src/ClientEngine.js
@@ -65,6 +65,11 @@ class ClientEngine {
         // console.log(world.stepCount - this.gameEngine.world.stepCount);
         // console.log("last handled input", world.lastHandledInput);
 
+        // release worldBuffer resources
+        if (this.worldBuffer.length > 0) {
+            this.worldBuffer[this.worldBuffer.length - 1].release();
+        }
+
         this.worldBuffer.push(worldSnapshot);
         if (this.worldBuffer.length >= 5) { //pick a proper buffer length, make it configurable
             this.worldBuffer.shift();
@@ -74,6 +79,9 @@ class ClientEngine {
             if (worldSnapshot.objects.hasOwnProperty(objId)) {
                 this.options.syncStrategy.handleObject(worldSnapshot, objId);
             }
+        }
+        if (typeof this.gameEngine.worldUpdateHandler === 'function') {
+            this.gameEngine.worldUpdateHandler();
         }
 
         //finally update the stepCount

--- a/src/GameWorld.js
+++ b/src/GameWorld.js
@@ -3,20 +3,10 @@
 const Serializable = require("./composables/Serializable");
 
 class GameWorld{
-
     constructor(){
         this.stepCount = 0;
         this.objects = {};
         this.playerCount = 0;
-    }
-
-    release() {
-        for (var objId in this.objects) {
-            let o = this.objects[objId];
-            if (typeof o.release === 'function') {
-                o.release();
-            }
-        }
     }
 
     static deserialize(gameEngine, worldData){

--- a/src/GameWorld.js
+++ b/src/GameWorld.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const Serializable = require("./Composables/Serializable");
+const Serializable = require("./composables/Serializable");
 
 class GameWorld{
 

--- a/src/GameWorld.js
+++ b/src/GameWorld.js
@@ -3,10 +3,20 @@
 const Serializable = require("./Composables/Serializable");
 
 class GameWorld{
+
     constructor(){
         this.stepCount = 0;
         this.objects = {};
         this.playerCount = 0;
+    }
+
+    release() {
+        for (var objId in this.objects) {
+            let o = this.objects[objId];
+            if (typeof o.release === 'function') {
+                o.release();
+            }
+        }
     }
 
     static deserialize(gameEngine, worldData){

--- a/src/ServerEngine.js
+++ b/src/ServerEngine.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const Gameloop = require('node-gameloop');
-const Serializable= require('./Composables/Serializable');
+const Serializable= require('./composables/Serializable');
 
 class ServerEngine{
 

--- a/src/syncStrategies/PlayerGradualSnap.js
+++ b/src/syncStrategies/PlayerGradualSnap.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var SyncStrategy = require("./SyncStrategy");
+var SyncStrategy = require("./syncStrategy");
 
 class PlayerGradualSnap extends SyncStrategy{
 

--- a/src/syncStrategies/PlayerSnap.js
+++ b/src/syncStrategies/PlayerSnap.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var SyncStrategy = require("./SyncStrategy");
+var SyncStrategy = require("./syncStrategy");
 
 /**
  * Snaps every object to its updated position from the server. Might cause rubber-banding on lagged connections


### PR DESCRIPTION
I needed to remove the old objects from the physics world before adding
new objects.  So this pull request introduces `GameWorld.release() `which calls
`release()` on each object.  The idea is that we may want to release extraneous object
data.


Maybe an even better approach is for each object to have a merge() method which receives
a server-side copy of the object, and it must update itself accordingly.  It could then handle the merge by adjusting it's coordinates incrementally.  In this model we don't even need to keep a buffer of older worlds.

Also in this pull request are some Linux case-sensitive fixes.