### PR TITLE
new events on gameEngine

### DIFF
--- a/src/GameEngine.js
+++ b/src/GameEngine.js
@@ -4,7 +4,7 @@ const Timer = require('./Timer');
 const EventEmitter = require('eventemitter3');
 
 class GameEngine{
-    constructor(inputOptions, physicsEngine){
+    constructor(inputOptions){
         //if no GameWorld is specified, use the default one
         this.options = Object.assign({
             GameWorld: GameWorld
@@ -12,8 +12,8 @@ class GameEngine{
 
         this.registeredClasses = {}; //todo be refactored into the serializer
 
-        if (physicsEngine) {
-            this.physicsEngine = physicsEngine;
+        if (this.options.physicsEngine) {
+            this.physicsEngine = this.options.physicsEngine;
             this.physicsEngine.init();
         }
 

--- a/src/ServerEngine.js
+++ b/src/ServerEngine.js
@@ -130,13 +130,16 @@ class ServerEngine{
         this.gameEngine.emit('playerJoinedOnServer', {
             playerId: playerId
         });
-        
+
         socket.emit('playerJoined',{
             playerId: playerId
         });
 
         socket.on('disconnect', function(){
-            that.onPlayerDisconnected(socket.id, playerId)
+            that.onPlayerDisconnected(socket.id, playerId);
+            that.gameEngine.emit('playerDisconnectedOnServer', {
+                playerId: playerId
+            });
         });
 
 

--- a/src/ServerEngine.js
+++ b/src/ServerEngine.js
@@ -127,7 +127,10 @@ class ServerEngine{
 
         console.log("Client Connected", socket.id);
 
-
+        this.gameEngine.emit('playerJoinedOnServer', {
+            playerId: playerId
+        });
+        
         socket.emit('playerJoined',{
             playerId: playerId
         });

--- a/src/ServerEngine.js
+++ b/src/ServerEngine.js
@@ -127,7 +127,7 @@ class ServerEngine{
 
         console.log("Client Connected", socket.id);
 
-        this.gameEngine.emit('playerJoinedOnServer', {
+        this.gameEngine.emit('server.playerJoined', {
             playerId: playerId
         });
 
@@ -137,7 +137,7 @@ class ServerEngine{
 
         socket.on('disconnect', function(){
             that.onPlayerDisconnected(socket.id, playerId);
-            that.gameEngine.emit('playerDisconnectedOnServer', {
+            that.gameEngine.emit('server.playerDisconnected', {
                 playerId: playerId
             });
         });
@@ -158,7 +158,7 @@ class ServerEngine{
         if (this.connectedPlayers[socket.id]) {
             this.connectedPlayers[socket.id].lastHandledInput = data.messageIndex;
         }
-        this.gameEngine.emit('inputReceivedOnServer', {
+        this.gameEngine.emit('server.inputReceived', {
             input: data,
             playerId: socket.playerId
         });

--- a/src/ServerEngine.js
+++ b/src/ServerEngine.js
@@ -158,6 +158,10 @@ class ServerEngine{
         if (this.connectedPlayers[socket.id]) {
             this.connectedPlayers[socket.id].lastHandledInput = data.messageIndex;
         }
+        this.gameEngine.emit('inputReceivedOnServer', {
+            input: data,
+            playerId: socket.playerId
+        });
         // console.log("last handled input", this.connectedPlayers[socket.id].lastHandledInput);
     }
 }


### PR DESCRIPTION
The following events on **gameEngine** will allow me to stop overriding **ServerEngine** and use it as-is.

- **playerJoinedOnServer** and **playerDisconnectedOnServer**.  The existing events (playerJoined and disconnect) do not work because they are emitted on the socket instead of on the **gameEngine**.  Should I rename the new events to "**server.playerJoined**" and "**server.playerDisconnected**" ?
- **inputReceivedOnServer**.  Should I rename this event to **server.inputReceived**?  

