### PR TITLE
add PhysicalObject class

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,7 +5,8 @@ var Incheon = {
     GameWorld: require("./src/GameWorld"),
     Point: require("./src/Point"),
     composables: {
-        Serializable: require("./src/composables/Serializable")
+        Serializable: require("./src/composables/Serializable"),
+        PhysicalObject: require("./src/composables/PhysicalObject")
     },
     physics: {
         PhysicsEngine: require("./src/physics/PhysicsEngine"),

--- a/src/composables/PhysicalObject.js
+++ b/src/composables/PhysicalObject.js
@@ -1,0 +1,72 @@
+"use strict";
+
+const Serializable = require('./Serializable');
+
+
+class PhysicalObject extends Serializable {
+
+    static get properties() {
+        return {
+            id: 7, // class id
+            name: "PhysicalObject"
+        };
+    }
+
+    static get netScheme() {
+        return {
+            id: {
+                type: Serializable.TYPES.UINT8
+            },
+            x: {
+                type: Serializable.TYPES.FLOAT32
+            },
+            y: {
+                type: Serializable.TYPES.FLOAT32
+            },
+            z: {
+                type: Serializable.TYPES.FLOAT32
+            },
+            rx: {
+                type: Serializable.TYPES.FLOAT32
+            },
+            ry: {
+                type: Serializable.TYPES.FLOAT32
+            },
+            rz: {
+                type: Serializable.TYPES.FLOAT32
+            },
+            velX: {
+                type: Serializable.TYPES.FLOAT32
+            },
+            velY: {
+                type: Serializable.TYPES.FLOAT32
+            },
+            velZ: {
+                type: Serializable.TYPES.FLOAT32
+            }
+        }
+    }
+
+    serialize() {
+        return super.serialize(arguments);
+    }
+
+    constructor(id, x, y, z, rx, ry, rz) {
+        super();
+        this.id = id; //instance id
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.rx = rx;
+        this.ry = ry;
+        this.rz = rz;
+        this.velX = 0;
+        this.velY = 0;
+        this.velZ = 0;
+        this.class = PhysicalObject;
+    };
+
+
+}
+
+module.exports = PhysicalObject;


### PR DESCRIPTION
This is the simple version.

I am planning a more complex version of the **PhysicalObject** which 
keeps a reference to the physical sub-object (only on server)
keeps a reference to the renderer sub-object (only on client)
calls `destroy()` on those subobjects (if they exist) when it is destroyed.
provides a `refreshRenderingAttributes()` method which collects current physical
position/rotation from the physical sub-object.  All of these methods 
are currently implemented in the derived class on my demo code.

An alternative is to create a class called **THREEPhysicalObject**
Let's chat tomorrow.